### PR TITLE
Register vocab file by correct file name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,7 @@ class KCStreetcarSkill(MycroftSkill):
         self.process = None
 
     def initialize(self):
-        intent = IntentBuilder("KCStreetcarIntent").require("next_car").build()
+        intent = IntentBuilder("KCStreetcarIntent").require("KCStreetcarSkill").build()
         self.register_intent(intent, self.handle_intent)
 
     def handle_intent(self, message):


### PR DESCRIPTION
It wasn't registering because the name didn't match the file in the vocab folder.

This gets it to register and recognize the command, but `self.speak_dialog` is looking for a template called `'the next streetcar...'`, so it throws an error. But it did make a request and get the time.

I think you have to create a template file for speech: http://mycroft-core.readthedocs.io/en/stable/source/mycroft.html#mycroft.MycroftSkill.speak_dialog

See how the version skill does it:

* https://github.com/MycroftAI/skill-version-checker/blob/master/dialog/en-us/version.dialog
* https://github.com/MycroftAI/skill-version-checker/blob/master/__init__.py#L47